### PR TITLE
Rate limit ioctl failures due to region database full messages

### DIFF
--- a/contrib/cray/Jenkinsfile
+++ b/contrib/cray/Jenkinsfile
@@ -2,10 +2,6 @@
 
 pipeline {
     options {
-        // We skip the default checkout from git so that we can
-        // wrap it in a retry() block to improve reliability.
-        skipDefaultCheckout(true)
-
         // Generic build options
         buildDiscarder(logRotator(numToKeepStr: '15'))
 
@@ -18,6 +14,7 @@ pipeline {
         timestamps()
         skipStagesAfterUnstable()
         parallelsAlwaysFailFast()
+        retry(3)
     }
     agent {
         node {
@@ -25,20 +22,6 @@ pipeline {
         }
     }
     stages {
-        stage('Clean Workspace') {
-            steps {
-                retry(3) {        // file system on wham is flakey,
-                    cleanWs()     // try multiple times
-                }
-            }
-        }
-        stage('Clone Kdreg2 Repo') {
-            steps {
-                retry(3) {        // connection to repo is somewhat flakey,
-                    checkout scm  // try multiple times
-                }
-            }
-        }
 	stage('Build Module') {
             steps {
                 sh "make modules"

--- a/dkms.conf.in
+++ b/dkms.conf.in
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Hewlett Packard Enterprise Development LP
+# Copyright 2023,2025 Hewlett Packard Enterprise Development LP
 #
 
 ## Global options
@@ -23,8 +23,8 @@ SHS_MAKE_ARGS="\
 # The default make command should be put into MAKE[0]. Other entries in the MAKE array will only be used
 #   if their corresponding entry in MAKE_MATCH[#] matches, as a regular expression (using egrep), the
 #   kernel that the module is being built for.
-MAKE="'make' ${SHS_MAKE_ARGS} modules"
-CLEAN="'make' ${SHS_MAKE_ARGS} clean"
+MAKE="'make' --jobs=${parallel_jobs} ${SHS_MAKE_ARGS} modules"
+CLEAN="'make' --jobs=${parallel_jobs} ${SHS_MAKE_ARGS} clean"
 
 ## SHS global default DKMS settings (expected to not change between any SHS components)
 # Rebuild and autoinstall automatically when dkms_autoinstaller runs for a new kernel

--- a/kdreg2.spec
+++ b/kdreg2.spec
@@ -65,6 +65,7 @@ Development files for Kdreg2 memory monitor
 %package dkms
 Summary:        DKMS support for %{name} kernel modules
 Requires: 	dkms
+Requires:	kdreg2
 Conflicts:      %{distro_kernel_package_name}
 BuildArch: 	noarch
 
@@ -149,6 +150,12 @@ ${postinst} %{name} %{version}-%{release}
 rm -f %{_modulesloaddir}/%{name}.conf || true
 
 %post
+# create module directory if necessary
+if [ ! -d %{_modulesloaddir} ]
+then
+	mkdir -p %{_modulesloaddir}
+fi
+
 # Create the systemd load file
 if [ ! -f %{_modulesloaddir}/%{name}.conf ]
 then

--- a/kdreg2_context.c
+++ b/kdreg2_context.c
@@ -148,7 +148,7 @@ int kdreg2_context_resize(struct kdreg2_context *context,
 	int ret;
 	size_t i, bad_index;
 
-	pr_info("resize to %zu entities", num_entities);
+	pr_info_ratelimited("resize to %zu entities", num_entities);
 
 	/* The free list uses the data field in the monitoring_data
 	 * as an index.  So we can only handle as many entities

--- a/kdreg2_file.c
+++ b/kdreg2_file.c
@@ -82,7 +82,7 @@ int kdreg2_open(struct inode *inode,
 
 	kdreg2_global_unlock();
 
-	pr_info("Instance opened.\n");
+	pr_info_ratelimited("Instance opened.\n");
 
 	return 0;
 
@@ -120,7 +120,7 @@ int kdreg2_release(struct inode *inode,
 
 	if (!file || !file->private_data) {
 		kdreg2_global_unlock();
-		pr_info("Instance closed, nothing to do.\n");
+		pr_info_ratelimited("Instance closed, nothing to do.\n");
 		return 0;
 	}
 
@@ -147,7 +147,7 @@ int kdreg2_release(struct inode *inode,
 	}
 
 	module_put(THIS_MODULE);
-	pr_info("Instance closed.\n");
+	pr_info_ratelimited("Instance closed.\n");
 
 	return 0;
 }

--- a/kdreg2_file.c
+++ b/kdreg2_file.c
@@ -487,8 +487,8 @@ long kdreg2_ioctl(struct file *file,
 		ret = (*ioctl_data[i].func)(context, arg);
 
 		if (ret)
-			pr_warn("%s: failure %i",
-				ioctl_data[i].ioctl_name, ret);
+			pr_warn_ratelimited("%s: failure %i",
+					    ioctl_data[i].ioctl_name, ret);
 		else
 			KDREG2_DEBUG(KDREG2_DEBUG_IOCTL, 1,
 				     "%s: success.",

--- a/kdreg2_priv.h
+++ b/kdreg2_priv.h
@@ -336,7 +336,7 @@ int kdreg2_detect_fork(struct kdreg2_context *context)
 		     current->mm, context->mm);
 
 	if (context->warn_on_fork_detected) {
-		pr_warn("Fork() detected - monitoring not supported in child");
+		pr_warn_ratelimited("Fork() detected - monitoring not supported in child");
 		context->warn_on_fork_detected = false;
 	}
 

--- a/kdreg2_region.c
+++ b/kdreg2_region.c
@@ -160,7 +160,7 @@ kdreg2_monitor_region(struct kdreg2_context *context,
 		if (!region_db->max_regions)
 			pr_warn("Attempt to register region when max_regions 0.");
 		else
-			pr_warn("Region database full, rejecting request to monitor region.");
+			pr_warn_ratelimited("Region database full, rejecting request to monitor region.");
 		ret = -ENOSPC;
 		goto err;
 	}


### PR DESCRIPTION
On Aurora when using kdreg2 the logs are flooded with region database full messages. This eventually causes our backend log aggregation system to be overwhelmed. So proposing to ratelimit these functions.

If there are other parts of the code such behavior is expected, would be good to ratelimit them as well.